### PR TITLE
ci: use new workflow syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,19 +3,20 @@ name: main
 on:
   push:
   pull_request:
-    types: [opened, synchronize]
 
 jobs:
   build:
     runs-on: ubuntu-18.04
-
+    defaults:
+      run:
+        working-directory: frontend
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - run: cd frontend && npm ci
-      - run: cd frontend && GH_CARD_IMAGE_SERVER_URL=https://gh-card.dev npm run build
+      - run: npm ci
+      - run: GH_CARD_IMAGE_SERVER_URL=https://gh-card.dev npm run build
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: main
 
-on:
-  push:
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
- Remove pull_request.types

cf. https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
> By default, a workflow only runs when a pull_request's activity type is opened, synchronize, or reopened.

- Use defaults.run.working-directory

cf. https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun